### PR TITLE
fix: rethrow original if both fail

### DIFF
--- a/src/SilentHunter.FileFormats/ChunkedFiles/DependencyInjectionChunkActivator.cs
+++ b/src/SilentHunter.FileFormats/ChunkedFiles/DependencyInjectionChunkActivator.cs
@@ -1,17 +1,18 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace SilentHunter.FileFormats.ChunkedFiles
 {
 	/// <summary>
-	/// Represents an activator for creating chunks with dependencies using <see cref="IServiceProvider"/>.
+	/// Represents an activator for creating chunks with dependencies using <see cref="IServiceProvider" />.
 	/// </summary>
 	public class DependencyInjectionChunkActivator : IChunkActivator
 	{
 		private readonly IServiceProvider _serviceProvider;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="DependencyInjectionChunkActivator"/> using specified <paramref name="serviceProvider"/> container.
+		/// Initializes a new instance of the <see cref="DependencyInjectionChunkActivator" /> using specified <paramref name="serviceProvider" /> container.
 		/// </summary>
 		/// <param name="serviceProvider">The service provider to use to create new chunk instances with dependencies.</param>
 		public DependencyInjectionChunkActivator(IServiceProvider serviceProvider)
@@ -20,7 +21,7 @@ namespace SilentHunter.FileFormats.ChunkedFiles
 		}
 
 		/// <summary>
-		/// Creates a chunk of type <paramref name="chunkType"/> with optional <paramref name="magic"/>, and injects it with dependencies from <see cref="IServiceProvider"/>.
+		/// Creates a chunk of type <paramref name="chunkType" /> with optional <paramref name="magic" />, and injects it with dependencies from <see cref="IServiceProvider" />.
 		/// </summary>
 		/// <param name="chunkType">The chunk type.</param>
 		/// <param name="magic">The magic.</param>
@@ -37,11 +38,18 @@ namespace SilentHunter.FileFormats.ChunkedFiles
 			{
 				return (IChunk)ActivatorUtilities.CreateInstance(_serviceProvider, chunkType);
 			}
-			catch (InvalidOperationException)
+			catch (InvalidOperationException ex)
 			{
 				if (magic != null)
 				{
-					return (IChunk)ActivatorUtilities.CreateInstance(_serviceProvider, chunkType, magic);
+					try
+					{
+						return (IChunk)ActivatorUtilities.CreateInstance(_serviceProvider, chunkType, magic);
+					}
+					catch
+					{
+						ExceptionDispatchInfo.Capture(ex).Throw();
+					}
 				}
 
 				throw;


### PR DESCRIPTION
Rethrowing the original exception can provide more relevant info if both invocations fail. F.ex. due to misconfiguration.